### PR TITLE
Expose register methods for each metric separately

### DIFF
--- a/src/main/java/com/github/cb372/metrics/sigar/CpuMetrics.java
+++ b/src/main/java/com/github/cb372/metrics/sigar/CpuMetrics.java
@@ -53,16 +53,29 @@ public class CpuMetrics extends AbstractSigarMetric {
     }
 
     public void registerGauges(MetricRegistry registry) {
+        registerTotalCores(registry);
+        registerPhysicalCpus(registry);
+        registerCpuTimeUserPercent(registry);
+        registerCpuTimeSysPercent(registry);
+    }
+
+    public void registerTotalCores(MetricRegistry registry) {
         registry.register(MetricRegistry.name(getClass(), "total-cores"), new Gauge<Integer>() {
             public Integer getValue() {
                 return totalCoreCount();
             }
         });
+    }
+
+    public void registerPhysicalCpus(MetricRegistry registry) {
         registry.register(MetricRegistry.name(getClass(), "physical-cpus"), new Gauge<Integer>() {
             public Integer getValue() {
                 return physicalCpuCount();
             }
         });
+    }
+
+    public void registerCpuTimeUserPercent(MetricRegistry registry) {
         registry.register(MetricRegistry.name(getClass(), "cpu-time-user-percent"), new RatioGauge() {
             @Override
             protected Ratio getRatio() {
@@ -78,11 +91,15 @@ public class CpuMetrics extends AbstractSigarMetric {
                 return userTime;
             }
         });
+    }
+
+    public void registerCpuTimeSysPercent(MetricRegistry registry) {
         registry.register(MetricRegistry.name(getClass(), "cpu-time-sys-percent"), new RatioGauge() {
             @Override
             protected Ratio getRatio() {
                 return Ratio.of(getNumerator(), 1.0);
             }
+
             private double getNumerator() {
                 List<CpuTime> cpus = cpus();
                 double userTime = 0.0;

--- a/src/main/java/com/github/cb372/metrics/sigar/MemoryMetrics.java
+++ b/src/main/java/com/github/cb372/metrics/sigar/MemoryMetrics.java
@@ -104,26 +104,46 @@ public class MemoryMetrics extends AbstractSigarMetric {
     }
 
     public void registerGauges(MetricRegistry registry) {
+        registerMemoryFree(registry);
+        registerMemoryActualFree(registry);
+        registerSwapFree(registry);
+        registerSwapPagesIn(registry);
+        registerSwapPagesOut(registry);
+    }
+
+    public void registerMemoryFree(MetricRegistry registry) {
         registry.register(MetricRegistry.name(getClass(), "memory-free"), new Gauge<Long>() {
             public Long getValue() {
                 return mem().free();
             }
         });
+    }
+
+    public void registerMemoryActualFree(MetricRegistry registry) {
         registry.register(MetricRegistry.name(getClass(), "memory-actual-free"), new Gauge<Long>() {
             public Long getValue() {
                 return mem().actualFree();
             }
         });
+    }
+
+    public void registerSwapFree(MetricRegistry registry) {
         registry.register(MetricRegistry.name(getClass(), "swap-free"), new Gauge<Long>() {
             public Long getValue() {
                 return swap().free();
             }
         });
+    }
+
+    public void registerSwapPagesIn(MetricRegistry registry) {
         registry.register(MetricRegistry.name(getClass(), "swap-pages-in"), new Gauge<Long>() {
             public Long getValue() {
                 return swap().pagesIn();
             }
         });
+    }
+
+    public void registerSwapPagesOut(MetricRegistry registry) {
         registry.register(MetricRegistry.name(getClass(), "swap-pages-out"), new Gauge<Long>() {
             public Long getValue() {
                 return swap().pagesOut();

--- a/src/main/java/com/github/cb372/metrics/sigar/UlimitMetrics.java
+++ b/src/main/java/com/github/cb372/metrics/sigar/UlimitMetrics.java
@@ -87,11 +87,19 @@ public class UlimitMetrics extends AbstractSigarMetric {
     }
 
     public void registerGauges(MetricRegistry registry) {
+        registerUlimitOpenFiles(registry);
+        registerUlimitStackSize(registry);
+    }
+
+    public void registerUlimitOpenFiles(MetricRegistry registry) {
         registry.register(MetricRegistry.name(getClass(), "ulimit-open-files"), new Gauge<Long>() {
             public Long getValue() {
                 return ulimit().openFiles();
             }
         });
+    }
+
+    public void registerUlimitStackSize(MetricRegistry registry) {
         registry.register(MetricRegistry.name(getClass(), "ulimit-stack-size"), new Gauge<Long>() {
             public Long getValue() {
                 return ulimit().stackSize();


### PR DESCRIPTION
This pull request exposes each of the default gauges with separate public methods. This allows a user to selectively register the ones he wants, instead of all in 1 go. For example, I only want system and user CPU percentage. With this pull request, this is now easily possible.
