### PR TITLE
Expose more of the memory metrics of Sigar

### DIFF
--- a/src/main/java/com/github/cb372/metrics/sigar/CpuMetrics.java
+++ b/src/main/java/com/github/cb372/metrics/sigar/CpuMetrics.java
@@ -60,7 +60,11 @@ public class CpuMetrics extends AbstractSigarMetric {
     }
 
     public void registerTotalCores(MetricRegistry registry) {
-        registry.register(MetricRegistry.name(getClass(), "total-cores"), new Gauge<Integer>() {
+        registerTotalCores(registry, MetricRegistry.name(getClass(), "total-cores"));
+    }
+
+    public void registerTotalCores(MetricRegistry registry, String name) {
+        registry.register(name, new Gauge<Integer>() {
             public Integer getValue() {
                 return totalCoreCount();
             }
@@ -68,7 +72,11 @@ public class CpuMetrics extends AbstractSigarMetric {
     }
 
     public void registerPhysicalCpus(MetricRegistry registry) {
-        registry.register(MetricRegistry.name(getClass(), "physical-cpus"), new Gauge<Integer>() {
+        registerPhysicalCpus(registry, MetricRegistry.name(getClass(), "physical-cpus"));
+    }
+
+    public void registerPhysicalCpus(MetricRegistry registry, String name) {
+        registry.register(name, new Gauge<Integer>() {
             public Integer getValue() {
                 return physicalCpuCount();
             }
@@ -76,7 +84,11 @@ public class CpuMetrics extends AbstractSigarMetric {
     }
 
     public void registerCpuTimeUserPercent(MetricRegistry registry) {
-        registry.register(MetricRegistry.name(getClass(), "cpu-time-user-percent"), new RatioGauge() {
+        registerCpuTimeUserPercent(registry, MetricRegistry.name(getClass(), "cpu-time-user-percent"));
+    }
+
+    public void registerCpuTimeUserPercent(MetricRegistry registry, String name) {
+        registry.register(name, new RatioGauge() {
             @Override
             protected Ratio getRatio() {
                 return Ratio.of(getNumerator(), 1.0);
@@ -94,7 +106,11 @@ public class CpuMetrics extends AbstractSigarMetric {
     }
 
     public void registerCpuTimeSysPercent(MetricRegistry registry) {
-        registry.register(MetricRegistry.name(getClass(), "cpu-time-sys-percent"), new RatioGauge() {
+        registerCpuTimeSysPercent(registry, MetricRegistry.name(getClass(), "cpu-time-sys-percent"));
+    }
+
+    public void registerCpuTimeSysPercent(MetricRegistry registry, String name) {
+        registry.register(name, new RatioGauge() {
             @Override
             protected Ratio getRatio() {
                 return Ratio.of(getNumerator(), 1.0);

--- a/src/main/java/com/github/cb372/metrics/sigar/MemoryMetrics.java
+++ b/src/main/java/com/github/cb372/metrics/sigar/MemoryMetrics.java
@@ -124,7 +124,11 @@ public class MemoryMetrics extends AbstractSigarMetric {
     }
 
     public void registerMemoryFree(MetricRegistry registry) {
-        registry.register(MetricRegistry.name(getClass(), "memory-free"), new Gauge<Long>() {
+        registerMemoryFree(registry, MetricRegistry.name(getClass(), "memory-free"));
+    }
+
+    public void registerMemoryFree(MetricRegistry registry, String name) {
+        registry.register(name, new Gauge<Long>() {
             public Long getValue() {
                 return mem().free();
             }
@@ -132,7 +136,11 @@ public class MemoryMetrics extends AbstractSigarMetric {
     }
 
     public void registerMemoryActualFree(MetricRegistry registry) {
-        registry.register(MetricRegistry.name(getClass(), "memory-actual-free"), new Gauge<Long>() {
+        registerMemoryActualFree(registry, MetricRegistry.name(getClass(), "memory-actual-free"));
+    }
+
+    public void registerMemoryActualFree(MetricRegistry registry, String name) {
+        registry.register(name, new Gauge<Long>() {
             public Long getValue() {
                 return mem().actualFree();
             }
@@ -140,7 +148,11 @@ public class MemoryMetrics extends AbstractSigarMetric {
     }
 
     public void registerMemoryUsed(MetricRegistry registry) {
-        registry.register(MetricRegistry.name(getClass(), "memory-used"), new Gauge<Long>() {
+        registerMemoryUsed(registry, MetricRegistry.name(getClass(), "memory-used"));
+    }
+
+    public void registerMemoryUsed(MetricRegistry registry, String name) {
+        registry.register(name, new Gauge<Long>() {
             public Long getValue() {
                 return mem().used();
             }
@@ -148,7 +160,11 @@ public class MemoryMetrics extends AbstractSigarMetric {
     }
 
     public void registerMemoryActualUsed(MetricRegistry registry) {
-        registry.register(MetricRegistry.name(getClass(), "memory-actual-used"), new Gauge<Long>() {
+        registerMemoryActualUsed(registry, MetricRegistry.name(getClass(), "memory-actual-used"));
+    }
+
+    public void registerMemoryActualUsed(MetricRegistry registry, String name) {
+        registry.register(name, new Gauge<Long>() {
             public Long getValue() {
                 return mem().actualUsed();
             }
@@ -156,7 +172,11 @@ public class MemoryMetrics extends AbstractSigarMetric {
     }
 
     public void registerMemoryTotal(MetricRegistry registry) {
-        registry.register(MetricRegistry.name(getClass(), "memory-total"), new Gauge<Long>() {
+        registerMemoryTotal(registry, MetricRegistry.name(getClass(), "memory-total"));
+    }
+
+    public void registerMemoryTotal(MetricRegistry registry, String name) {
+        registry.register(name, new Gauge<Long>() {
             public Long getValue() {
                 return mem().total();
             }
@@ -164,7 +184,11 @@ public class MemoryMetrics extends AbstractSigarMetric {
     }
 
     public void registerMemoryUsedPercent(MetricRegistry registry) {
-        registry.register(MetricRegistry.name(getClass(), "memory-used-percent"), new Gauge<Double>() {
+        registerMemoryUsedPercent(registry, MetricRegistry.name(getClass(), "memory-used-percent"));
+    }
+
+    public void registerMemoryUsedPercent(MetricRegistry registry, String name) {
+        registry.register(name, new Gauge<Double>() {
             public Double getValue() {
                 return mem().usedPercent();
             }
@@ -172,7 +196,11 @@ public class MemoryMetrics extends AbstractSigarMetric {
     }
 
     public void registerMemoryFreePercent(MetricRegistry registry) {
-        registry.register(MetricRegistry.name(getClass(), "memory-free-percent"), new Gauge<Double>() {
+        registerMemoryFreePercent(registry, MetricRegistry.name(getClass(), "memory-free-percent"));
+    }
+
+    public void registerMemoryFreePercent(MetricRegistry registry, String name) {
+        registry.register(name, new Gauge<Double>() {
             public Double getValue() {
                 return mem().freePercent();
             }
@@ -180,7 +208,11 @@ public class MemoryMetrics extends AbstractSigarMetric {
     }
 
     public void registerSwapFree(MetricRegistry registry) {
-        registry.register(MetricRegistry.name(getClass(), "swap-free"), new Gauge<Long>() {
+        registerSwapFree(registry, MetricRegistry.name(getClass(), "swap-free"));
+    }
+
+    public void registerSwapFree(MetricRegistry registry, String name) {
+        registry.register(name, new Gauge<Long>() {
             public Long getValue() {
                 return swap().free();
             }
@@ -188,7 +220,11 @@ public class MemoryMetrics extends AbstractSigarMetric {
     }
 
     public void registerSwapPagesIn(MetricRegistry registry) {
-        registry.register(MetricRegistry.name(getClass(), "swap-pages-in"), new Gauge<Long>() {
+        registerSwapPagesIn(registry, MetricRegistry.name(getClass(), "swap-pages-in"));
+    }
+
+    public void registerSwapPagesIn(MetricRegistry registry, String name) {
+        registry.register(name, new Gauge<Long>() {
             public Long getValue() {
                 return swap().pagesIn();
             }
@@ -196,7 +232,11 @@ public class MemoryMetrics extends AbstractSigarMetric {
     }
 
     public void registerSwapPagesOut(MetricRegistry registry) {
-        registry.register(MetricRegistry.name(getClass(), "swap-pages-out"), new Gauge<Long>() {
+        registerSwapPagesOut(registry, MetricRegistry.name(getClass(), "swap-pages-out"));
+    }
+
+    public void registerSwapPagesOut(MetricRegistry registry, String name) {
+        registry.register(name, new Gauge<Long>() {
             public Long getValue() {
                 return swap().pagesOut();
             }

--- a/src/main/java/com/github/cb372/metrics/sigar/MemoryMetrics.java
+++ b/src/main/java/com/github/cb372/metrics/sigar/MemoryMetrics.java
@@ -31,27 +31,34 @@ public class MemoryMetrics extends AbstractSigarMetric {
 
     public static final class MainMemory extends MemSegment {
         private final long actualUsed, actualFree;
+        private final double usedPercent, freePercent;
     
         private MainMemory(//
                 long total, long used, long free, //
-                long actualUsed, long actualFree) {
+                long actualUsed, long actualFree,
+                double usedPercent, double freePercent) {
             super(total, used, free);
             this.actualUsed = actualUsed;
             this.actualFree = actualFree;
+            this.usedPercent = usedPercent;
+            this.freePercent = freePercent;
         }
 
         public static MainMemory fromSigarBean(Mem mem) {
             return new MainMemory( //
                     mem.getTotal(), mem.getUsed(), mem.getFree(), //
-                    mem.getActualUsed(), mem.getActualFree()); 
+                    mem.getActualUsed(), mem.getActualFree(),
+                    mem.getUsedPercent(), mem.getFreePercent());
         }
 
         private static MainMemory undef() {
-            return new MainMemory(-1L, -1L, -1L, -1L, -1L);
+            return new MainMemory(-1L, -1L, -1L, -1L, -1L, -1, -1);
         }
         
         public long actualUsed() { return actualUsed; }
         public long actualFree() { return actualFree; }
+        public double usedPercent() { return usedPercent; }
+        public double freePercent() { return freePercent; }
     }
 
     public static final class SwapSpace extends MemSegment {
@@ -106,6 +113,11 @@ public class MemoryMetrics extends AbstractSigarMetric {
     public void registerGauges(MetricRegistry registry) {
         registerMemoryFree(registry);
         registerMemoryActualFree(registry);
+        registerMemoryUsed(registry);
+        registerMemoryActualUsed(registry);
+        registerMemoryTotal(registry);
+        registerMemoryUsedPercent(registry);
+        registerMemoryFreePercent(registry);
         registerSwapFree(registry);
         registerSwapPagesIn(registry);
         registerSwapPagesOut(registry);
@@ -123,6 +135,46 @@ public class MemoryMetrics extends AbstractSigarMetric {
         registry.register(MetricRegistry.name(getClass(), "memory-actual-free"), new Gauge<Long>() {
             public Long getValue() {
                 return mem().actualFree();
+            }
+        });
+    }
+
+    public void registerMemoryUsed(MetricRegistry registry) {
+        registry.register(MetricRegistry.name(getClass(), "memory-used"), new Gauge<Long>() {
+            public Long getValue() {
+                return mem().used();
+            }
+        });
+    }
+
+    public void registerMemoryActualUsed(MetricRegistry registry) {
+        registry.register(MetricRegistry.name(getClass(), "memory-actual-used"), new Gauge<Long>() {
+            public Long getValue() {
+                return mem().actualUsed();
+            }
+        });
+    }
+
+    public void registerMemoryTotal(MetricRegistry registry) {
+        registry.register(MetricRegistry.name(getClass(), "memory-total"), new Gauge<Long>() {
+            public Long getValue() {
+                return mem().total();
+            }
+        });
+    }
+
+    public void registerMemoryUsedPercent(MetricRegistry registry) {
+        registry.register(MetricRegistry.name(getClass(), "memory-used-percent"), new Gauge<Double>() {
+            public Double getValue() {
+                return mem().usedPercent();
+            }
+        });
+    }
+
+    public void registerMemoryFreePercent(MetricRegistry registry) {
+        registry.register(MetricRegistry.name(getClass(), "memory-free-percent"), new Gauge<Double>() {
+            public Double getValue() {
+                return mem().freePercent();
             }
         });
     }

--- a/src/main/java/com/github/cb372/metrics/sigar/UlimitMetrics.java
+++ b/src/main/java/com/github/cb372/metrics/sigar/UlimitMetrics.java
@@ -92,7 +92,11 @@ public class UlimitMetrics extends AbstractSigarMetric {
     }
 
     public void registerUlimitOpenFiles(MetricRegistry registry) {
-        registry.register(MetricRegistry.name(getClass(), "ulimit-open-files"), new Gauge<Long>() {
+        registerUlimitOpenFiles(registry, MetricRegistry.name(getClass(), "ulimit-open-files"));
+    }
+
+    public void registerUlimitOpenFiles(MetricRegistry registry, String name) {
+        registry.register(name, new Gauge<Long>() {
             public Long getValue() {
                 return ulimit().openFiles();
             }
@@ -100,7 +104,11 @@ public class UlimitMetrics extends AbstractSigarMetric {
     }
 
     public void registerUlimitStackSize(MetricRegistry registry) {
-        registry.register(MetricRegistry.name(getClass(), "ulimit-stack-size"), new Gauge<Long>() {
+        registerUlimitStackSize(registry, MetricRegistry.name(getClass(), "ulimit-stack-size"));
+    }
+
+    public void registerUlimitStackSize(MetricRegistry registry, String name) {
+        registry.register(name, new Gauge<Long>() {
             public Long getValue() {
                 return ulimit().stackSize();
             }


### PR DESCRIPTION
This PR will add more of the memory metrics. The following have been added:
- used memory
- actual used memory
- total memory
- used percentage
- free percentage

It also allows users to optionally specify the name in case they don't like the default names.
